### PR TITLE
New path for profile.boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ $ boot -d boot-deps latest -l org.clojure/clojure -q
 Searching for latest version of [org.clojure/clojure]...: 1.7.0-RC1
 ```
 
-If you want to have `boot-deps` available globally you can add it to your `~/.profile.boot` like so:
+If you want to have `boot-deps` available globally you can add it to your `$BOOT_HOME/profile.boot` (usually `$BOOT_HOME` is set to `~/.boot`, see `boot -h` for details) like so:
 
 ```clojure
-(set-env! :dependencies '[[boot-deps "0.1.4"]])
+(set-env! :dependencies '[[boot-deps "0.1.6"]])
 (require '[boot-deps :refer [ancient]])
 ```
 


### PR DESCRIPTION
According to https://github.com/boot-clj/boot/issues/157 profile script is moved to $BOOT_HOME