### PR TITLE
Update ancient-clj to fix incompatibility with clojure 1.9.0

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,15 +1,15 @@
 (set-env!
   :source-paths #{"src"}
-  :dependencies '[[adzerk/bootlaces    "0.1.11" :scope "test"]])
+  :dependencies '[[adzerk/bootlaces "0.1.13" :scope "test"]])
 
 (require '[adzerk.bootlaces :refer :all])
 
-(def +version+ "0.1.6")
+(def +version+ "0.1.7")
 
 (bootlaces! +version+)
 
 (task-options!
- pom  {:project     'boot-deps
+  pom {:project     'boot-deps
        :version     +version+
        :description "Boot task to find outdated dependencies."
        :url         "https://github.com/martinklepsch/boot-deps"

--- a/src/boot_deps.clj
+++ b/src/boot_deps.clj
@@ -9,8 +9,8 @@
 (def initial
   (atom true))
 
-(defn make-ancient-pod []
-  (pod/make-pod (assoc (boot/get-env) :dependencies '[[ancient-clj "0.2.1"]])))
+(defn make-ancient-pod []                             ;; need slingshot b/c ancient-clj has :exclusions on it and clj-http needs it
+  (pod/make-pod (assoc (boot/get-env) :dependencies '[[slingshot "0.12.2"] [ancient-clj "0.3.14"]])))
 
 (defn find-outdated [env opts]
   (let [ancient-pod (make-ancient-pod)


### PR DESCRIPTION
Running the `ancient` task with Clojure 1.9.0-alpha11 produces this error:

```
clojure.lang.ExceptionInfo: java.lang.IllegalArgumentException: Call to clojure.core/defn- did not conform to spec:
                                         In: [0] val: clj-tuple/conj-tuple fails spec: :clojure.core.specs/defn-args at: [:args :name] predicate: simple-symbol?
                                         :clojure.spec/args  (clj-tuple/conj-tuple [t__1446__unified__ x__1447__unified__] (clojure.core/let [t__1446__unified__ t__1446__unified__] (clojure.core/case (.count t__1446__unified__) 0 (new Tuple1 x__1447__unified__ (clojure.core/meta t__1446__unified__)) 1 (new Tuple2 (. t__1446__unified__ e0) x__1447__unified__ (clojure.core/meta t__1446__unified__)) 2 (new Tuple3 (. t__1446__unified__ e0) (. t__1446__unified__ e1) x__1447__unified__ (clojure.core/meta t__1446__unified__)) 3 (new Tuple4 (. t__1446__unified__ e0) (. t__1446__unified__ e1) (. t__1446__unified__ e2) x__1447__unified__ (clojure.core/meta t__1446__unified__)) 4 (new Tuple5 (. t__1446__unified__ e0) (. t__1446__unified__ e1) (. t__1446__unified__ e2) (. t__1446__unified__ e3) x__1447__unified__ (clojure.core/meta t__1446__unified__)) 5 (new Tuple6 (. t__1446__unified__ e0) (. t__1446__unified__ e1) (. t__1446__unified__ e2) (. t__1446__unified__ e3) (. t__1446__unified__ e4) x__1447__unified__ (clojure.core/meta t__1446__unified__)) 6 (clojure.core/let [t__1446__unified__ t__1446__unified__] (clj_tuple.VectorSeq. 0 7 (clojure.core/-> [] clojure.core/transient (clojure.core/conj! (.nth t__1446__unified__ 0)) (clojure.core/conj! (.nth t__1446__unified__ 1)) (clojure.core/conj! (.nth t__1446__unified__ 2)) (clojure.core/conj! (.nth t__1446__unified__ 3)) (clojure.core/conj! (.nth t__1446__unified__ 4)) (clojure.core/conj! (.nth t__1446__unified__ 5)) (clojure.core/conj! x__1447__unified__) clojure.core/persistent!) (clojure.core/meta t__1446__unified__))))))
                                         , compiling:(clj_tuple.clj:589:1)
```

This seems to be resolved by updating ancient-clj to the latest version. I had to add slingshot to the pod's dependencies because ancient-clj has it in `:exclusions` and clj-http requires it. 
