### PR TITLE
Add :upgrade? false feature from lein-ancient

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Searching for latest version of [org.clojure/clojure]...: 1.7.0-RC1
 If you want to have `boot-deps` available globally you can add it to your `$BOOT_HOME/profile.boot` (usually `$BOOT_HOME` is set to `~/.boot`, see `boot -h` for details) like so:
 
 ```clojure
-(set-env! :dependencies '[[boot-deps "0.1.6"]])
+(set-env! :dependencies '[[boot-deps "0.1.7"]])
 (require '[boot-deps :refer [ancient]])
 ```
 


### PR DESCRIPTION
I know I said just a day ago I didn't expect any more updates to this library, but my team ran into one last thing we used from lein-ancient. :sweat: 

lein-ancient let's you put an `:upgrade? false` flag in your dependency vector which tells lein-ancient not to print out that dependency in the outdated list. It's useful in scenarios where you know you can't update a few dependencies right now, but just want to see if there are any other upgrades to do.

I tested this code out and it works as expected.