### PR TITLE
Update to the latest ancient-clj

### DIFF
--- a/src/boot_deps.clj
+++ b/src/boot_deps.clj
@@ -10,7 +10,7 @@
   (atom true))
 
 (defn make-ancient-pod [] ;; need slingshot b/c ancient-clj has :exclusions on it and clj-http needs it
-  (pod/make-pod (assoc (boot/get-env) :dependencies '[[slingshot "0.12.2"] [ancient-clj "0.3.14"]])))
+  (pod/make-pod (assoc (boot/get-env) :dependencies '[[slingshot "0.12.2"] [ancient-clj "0.6.15"]])))
 
 (defn- skip-upgrade-check?
   [[_ _ & opts]]


### PR DESCRIPTION
This allows repositories using s3 to fallback to the default system
aws credentials when they aren't specified in the repository map